### PR TITLE
Add install includedir to jsoncpp_headers target

### DIFF
--- a/src/lib_json/CMakeLists.txt
+++ b/src/lib_json/CMakeLists.txt
@@ -80,6 +80,7 @@ target_include_directories( jsoncppobj_lib PRIVATE
 								
 	add_library(jsoncpp_headers INTERFACE)
 	set_property(TARGET jsoncpp_headers PROPERTY INTERFACE_INCLUDE_DIRECTORIES
+				$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
                                 $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/${JSONCPP_INCLUDE_DIR}>)
 	install( TARGETS jsoncpp_headers ${INSTALL_EXPORT})
 								


### PR DESCRIPTION
Adds CMAKE_INSTALL_INCLUDEDIR to the jsoncpp_headers target, so it will get populated correctly in the exported install target.